### PR TITLE
Update __init__.py

### DIFF
--- a/apache/flask/webapp/__init__.py
+++ b/apache/flask/webapp/__init__.py
@@ -1131,7 +1131,8 @@ def create_app():
             internalDeviceInfo={}
             alertInfo['mac'] = 'system'
         es.write(esService, alertInfo, 'sweet_security_alerts', 'alerts')
-        email.emailUser(mail,"New Sweet Security Alert",recipient,alertMessage)
+        # Uncomment line below after include ALL alerts in email config
+        #email.emailUser(mail,"New Sweet Security Alert",recipient,alertMessage)
         return jsonify(status='200',alertType=alertType,alertMessage=alertMessage,logInfo=logInfo,internalDeviceInfo=internalDeviceInfo)
 
     @app.route('/alerts')


### PR DESCRIPTION
During initial setup and baseline, emails for every alert are overwhelming.  Perhaps starting with the "New Sweet Security Alert" email.emailUser line commented out would allow for baselining, then remove comment once normalized/tuned.

Would be fine as-is for an on-prem smtp server, but not so much for gmail, etc.